### PR TITLE
maint-bump jackson-databind to 2.9.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.9.10.4</jackson.version>
+        <jackson.version>2.9.10.5</jackson.version>
         <slf4j.version>1.8.0-beta4</slf4j.version>
         <junit.jupiter.version>5.4.2</junit.jupiter.version>
     </properties>


### PR DESCRIPTION
This commit updates jackson-databind to cover the following CVEs:

- CVE-2020-14062
- CVE-2020-14060
- CVE-2020-14195
- CVE-2020-14061