### PR TITLE
(maint) update msgpack, jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>com.puppet</groupId>
     <artifactId>pcore</artifactId>
-    <version>0.1.8</version>
+    <version>0.1.9</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.9.10.7</jackson.version>
+        <jackson.version>2.12.1</jackson.version>
         <slf4j.version>1.8.0-beta4</slf4j.version>
         <junit.jupiter.version>5.4.2</junit.jupiter.version>
     </properties>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.msgpack</groupId>
             <artifactId>msgpack-core</artifactId>
-            <version>0.8.16</version>
+            <version>0.8.21</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This commit updates the following dependencies to resolve
some security issues

- msgpack-core to 0.8.21 (CVE-2020-5234)
- jackson-databind to 2.12.1 (many)

Also updates the pcore version to 0.1.9 in preparation for a new
release.