### PR TITLE
(maint) Remove unnecessary fragile test

### DIFF
--- a/src/test/java/com/puppet/pcore/impl/TypeCalculatorTest.java
+++ b/src/test/java/com/puppet/pcore/impl/TypeCalculatorTest.java
@@ -185,13 +185,6 @@ public class TypeCalculatorTest {
 				assertInfer(typeType(type), type);
 		}
 
-		@Test
-		@DisplayName("Basic types _ptype")
-		public void inferBasicTypesPtype() {
-			for(AnyType type: TypeEvaluatorImpl.BASIC_TYPES.values())
-				assertEquals(String.format("Pcore::%sType", type.name()), type._pcoreType().name());
-		}
-
 		private void assertInfer(AnyType expected, Object value) {
 			assertEquals(expected, infer(value));
 		}


### PR DESCRIPTION
This test isn't actually using any methods of the TypeCalculator class
it purports to test, and is fragile because it relies on other tests
having run first to set up Pcore.