### PR TITLE
(maint) Avoid recursively parsing duration formats

### DIFF
--- a/src/main/java/com/puppet/pcore/impl/TypeFormatter.java
+++ b/src/main/java/com/puppet/pcore/impl/TypeFormatter.java
@@ -163,7 +163,7 @@ public class TypeFormatter extends Polymorphic<Void> {
 	}
 
 	void _format(Duration value) {
-		_format(DurationFormat.DEFAULTS.get(0).format(value));
+		_format(DurationFormat.defaultFormat(value));
 	}
 
 	void _format(Instant value) {

--- a/src/main/java/com/puppet/pcore/time/DurationFormat.java
+++ b/src/main/java/com/puppet/pcore/time/DurationFormat.java
@@ -392,8 +392,8 @@ public class DurationFormat {
 		}
 	}
 
-	public static final List<DurationFormat> DEFAULTS = Collections.unmodifiableList(
-			map(asList("%D-%H:%M:%S.%-N", "%H:%M:%S.%-N", "%M:%S.%-N", "%S.%-N", "%D-%H:%M:%S", "%H:%M:%S", "%D-%H:%M", "%S"), FormatParser.singleton::parseFormat));
+	public static final List<String> DEFAULT_FORMATS = Collections.unmodifiableList(
+			asList("%D-%H:%M:%S.%-N", "%H:%M:%S.%-N", "%M:%S.%-N", "%S.%-N", "%D-%H:%M:%S", "%H:%M:%S", "%D-%H:%M", "%S"));
 	private static final long NSECS_PER_USEC = 1000;
 	private static final long NSECS_PER_MSEC = NSECS_PER_USEC * 1000;
 	private static final long NSECS_PER_SEC = NSECS_PER_MSEC * 1000;
@@ -410,19 +410,11 @@ public class DurationFormat {
 	}
 
 	public static Duration defaultParse(String timeSpan) {
-		for(DurationFormat format : DEFAULTS) {
-			try {
-				return format.parse(timeSpan);
-			} catch(IllegalArgumentException ignored) {
-			}
-		}
-		throw new IllegalArgumentException(String.format(
-				"Unable to parse '%s' using any of the default formats",
-				timeSpan));
+    return parse(timeSpan, DEFAULT_FORMATS);
 	}
 
 	public static String defaultFormat(Duration timeSpan) {
-		return DEFAULTS.get(0).format(timeSpan);
+		return format(timeSpan, DEFAULT_FORMATS.get(0));
 	}
 
 	public static Duration parse(String timeSpan, List<String> formats) {


### PR DESCRIPTION
Previously, FormatParser.singleton.parseFormat could throw a
ConcurrentModificationException because it was possible for that method
to cause a second nested parseFormat call to happen.

This occurred because of the static DEFAULTS field on DurationFormat,
which contained a list of DurationFormat instances computed by calling
parseFormat on a list of strings. Because it's a static field, it was
computed the first time the class was referenced. Since the FormatParser
class keeps a HashMap<String,DurationFormat>, it was possible for that
first reference (at least in tests) to happen when
FormatParser.singleton.parseFormat was called.

That method uses HashMap.computeIfAbsent to only parse and add the
format if it's not already present. An important requirement for
computeIfAbsent is that the method used to do the computing *must not*
modify the HashMap, or a ConcurrentModificationException can be thrown.
Since the parseFormat method references the "formats" map which
references the DurationFormat, that method could cause an additional
parse to happen during the original parse, throwing that exception.

We now store a list of format strings on DurationFormat (now called
DEFAULT_FORMATS) rather than a list of DurationFormat instances. This
means they will only be computed when *needed*, not when the
DurationFormat class is referenced, avoiding the automatic nesterd calls
to parseFormat. It also brings the defaultParse() method (which parses a
duration with all of the default formats) in line with the parse()
method (which parses a duration with a list of formats), as the latter
method expects a list of strings.

This means that now both the defaultFormat() and defaultParse() methods
are just simple calls to the format() and parse() methods, passing in
defaults.